### PR TITLE
Dev/rework dvc pipeline

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,6 @@
 [core]
     remote = my_dvc_remote
+[hydra]
+    enabled = True
 ['remote "my_dvc_remote"']
     url = F:/my_dvc_remote

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 /data
 /outs
 /dvc_plots
+
+# VSCode
+.vscode

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,0 +1,28 @@
+general:
+  device: "cuda"
+  embedding_dim: 32
+  do_norm: True 
+
+dataset:
+  specific_clusters:
+    - 0
+  n_images: 128
+  shuffle: True
+
+autoencoder:
+  adversarial_loss_weight: 1.0
+  batch_size: 512
+  epochs_mnist: 20
+  epochs_lld: 200
+  kl_loss_weight: 1.0
+  learning_rate: 4e-4
+
+diffusion:
+  batch_size: 32
+  epochs_mnist: 20
+  epochs_lld: 201
+  guiding_factor: 0.90
+  learning_rate: 1e-2
+  steps: 1000
+  var_schedule_start: 0.0001
+  var_schedule_end: 0.02

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,24 +1,24 @@
 defaults:
-  - dataset: mnist
+  - dataset: lld
   - _self_
 
 general:
   device: "cuda"
   embedding_dim: 32
-  do_norm: True 
+  do_norm: True
 
 autoencoder:
   adversarial_loss_weight: 1.0
   batch_size: 512
   epochs_mnist: 20
-  epochs_lld: 200
+  epochs_lld: 100
   kl_loss_weight: 1.0
   learning_rate: 4e-4
 
 diffusion:
   batch_size: 32
   epochs_mnist: 20
-  epochs_lld: 201
+  epochs_lld: 100
   guiding_factor: 0.90
   learning_rate: 1e-2
   steps: 1000

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,13 +1,11 @@
+defaults:
+  - dataset: mnist
+  - _self_
+
 general:
   device: "cuda"
   embedding_dim: 32
   do_norm: True 
-
-dataset:
-  specific_clusters:
-    - 0
-  n_images: 128
-  shuffle: True
 
 autoencoder:
   adversarial_loss_weight: 1.0

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,26 +1,9 @@
 defaults:
   - dataset: lld
+  - model: diffusion
   - _self_
 
 general:
   device: "cuda"
   embedding_dim: 32
   do_norm: True
-
-autoencoder:
-  adversarial_loss_weight: 1.0
-  batch_size: 512
-  epochs_mnist: 20
-  epochs_lld: 100
-  kl_loss_weight: 1.0
-  learning_rate: 4e-4
-
-diffusion:
-  batch_size: 32
-  epochs_mnist: 20
-  epochs_lld: 100
-  guiding_factor: 0.90
-  learning_rate: 1e-2
-  steps: 1000
-  var_schedule_start: 0.0001
-  var_schedule_end: 0.02

--- a/conf/dataset/lld.yaml
+++ b/conf/dataset/lld.yaml
@@ -1,5 +1,7 @@
 name: "LLD"
 specific_clusters:
   - 0
-n_images: 128
+  - 1
+  - 2
+n_images: !!null
 shuffle: True

--- a/conf/dataset/lld.yaml
+++ b/conf/dataset/lld.yaml
@@ -1,0 +1,5 @@
+name: "LLD"
+specific_clusters:
+  - 0
+n_images: 128
+shuffle: True

--- a/conf/dataset/mnist.yaml
+++ b/conf/dataset/mnist.yaml
@@ -1,0 +1,3 @@
+name: "MNIST"
+n_images: 128
+shuffle: True

--- a/conf/dataset/mnist.yaml
+++ b/conf/dataset/mnist.yaml
@@ -1,3 +1,3 @@
 name: "MNIST"
-n_images: 128
+n_images: !!null
 shuffle: True

--- a/conf/model/autoencoder.yaml
+++ b/conf/model/autoencoder.yaml
@@ -1,0 +1,6 @@
+  adversarial_loss_weight: 1.0
+  batch_size: 512
+  epochs_mnist: 20
+  epochs_lld: 100
+  kl_loss_weight: 1.0
+  learning_rate: 4e-4

--- a/conf/model/diffusion.yaml
+++ b/conf/model/diffusion.yaml
@@ -1,0 +1,8 @@
+  batch_size: 32
+  epochs_mnist: 20
+  epochs_lld: 10
+  guiding_factor: 0.90
+  learning_rate: 1e-2
+  steps: 1000
+  var_schedule_start: 0.0001
+  var_schedule_end: 0.02

--- a/dvc.lock
+++ b/dvc.lock
@@ -77,13 +77,9 @@ stages:
   draw_samples:
     cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
-    - path: outs/train_autoencoder/model.pt
+    - path: outs/model.pt
       hash: md5
-      md5: 8ecd7ba7a09263204f00470d8ce2fb19
-      size: 18708753
-    - path: outs/train_diffusion_model/model.pt
-      hash: md5
-      md5: 956651012fd4d4018424a453a2d34710
+      md5: 558d9c023962b62993dbd8b369acb6d8
       size: 58607529
     params:
       params.yaml:
@@ -258,3 +254,42 @@ stages:
       hash: md5
       md5: 7785b32060090ef63ded457db404bdb3
       size: 58607273
+  train_model:
+    cmd: python favicon_gen/call_training.py
+    deps:
+    - path: data/LLD-icon.hdf5
+      hash: md5
+      md5: 91f56af2235117e44629fa608fed59ef
+      size: 798927457
+    params:
+      params.yaml:
+        dataset:
+          name: LLD
+          specific_clusters:
+          - 0
+          - 1
+          - 2
+          n_images:
+          shuffle: true
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
+        model:
+          batch_size: 32
+          epochs_mnist: 20
+          epochs_lld: 10
+          guiding_factor: 0.9
+          learning_rate: 0.01
+          steps: 1000
+          var_schedule_start: 0.0001
+          var_schedule_end: 0.02
+    outs:
+    - path: outs/loss.csv
+      hash: md5
+      md5: c4a2d70179ef5d8ea5b1656423d9f074
+      size: 237
+    - path: outs/model.pt
+      hash: md5
+      md5: 558d9c023962b62993dbd8b369acb6d8
+      size: 58607529

--- a/dvc.lock
+++ b/dvc.lock
@@ -79,7 +79,7 @@ stages:
     deps:
     - path: outs/model.pt
       hash: md5
-      md5: 558d9c023962b62993dbd8b369acb6d8
+      md5: 187e6851ab413a10868144acad804e83
       size: 58607529
     params:
       params.yaml:
@@ -287,9 +287,9 @@ stages:
     outs:
     - path: outs/loss.csv
       hash: md5
-      md5: c4a2d70179ef5d8ea5b1656423d9f074
-      size: 237
+      md5: f260ed0748ca93ad1cd582e88909ae16
+      size: 240
     - path: outs/model.pt
       hash: md5
-      md5: 558d9c023962b62993dbd8b369acb6d8
+      md5: 187e6851ab413a10868144acad804e83
       size: 58607529

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,68 +1,88 @@
 schema: '2.0'
 stages:
   train_autoencoder:
-    cmd: python logo_maker/autoencoder.py
+    cmd: python favicon_gen/autoencoder.py
     deps:
     - path: data/LLD-icon.hdf5
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      logo_maker/params.py:
-        AutoEncoderParams:
-          ADVERSARIAL_LOSS_WEIGHT: 1
-          BATCH_SIZE: 128
-          EPOCHS: 50
-          KL_LOSS_WEIGHT: 1
-          LEARNING_RATE: 0.0004
-        DatasetParams:
-          CLUSTER:
-          N_IMAGES: 37376
-          SHUFFLE_DATA: true
-          USE_MNIST: true
+      params.yaml:
+        autoencoder:
+          adversarial_loss_weight: 1.0
+          batch_size: 512
+          epochs_mnist: 20
+          epochs_lld: 200
+          kl_loss_weight: 1.0
+          learning_rate: 0.0004
+        dataset:
+          name: MNIST
+          n_images: 128
+          shuffle: true
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_autoencoder/loss.csv
-      md5: 8c9796046f1144c2ba476bccde401b72
-      size: 1166
+      hash: md5
+      md5: 36a45f9cdde04875f0f292a1e136d408
+      size: 458
     - path: outs/train_autoencoder/model.pt
-      md5: b205f79b4d6d26f5730e630af8d80e9e
-      size: 3477013
+      hash: md5
+      md5: 7b9709dcb5c1affd0bb29c83fe120225
+      size: 18705937
   train_diffusion_model:
-    cmd: python logo_maker/denoising_diffusion.py
+    cmd: python favicon_gen/denoising_diffusion.py
     deps:
     - path: data/LLD-icon.hdf5
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      logo_maker/params.py:
-        DatasetParams:
-          CLUSTER:
-          N_IMAGES: 37376
-          SHUFFLE_DATA: true
-          USE_MNIST: true
-        DiffusionModelParams:
-          BATCH_SIZE: 128
-          DIFFUSION_STEPS: 1000
-          EMBEDDING_DIMENSION: 32
-          EPOCHS: 10
-          LEARNING_RATE: 0.001
-          VAR_SCHEDULE_START: 0.0001
-          VAR_SCHEDULE_END: 0.02
+      params.yaml:
+        dataset:
+          name: MNIST
+          n_images: 128
+          shuffle: true
+        diffusion:
+          batch_size: 32
+          epochs_mnist: 20
+          epochs_lld: 201
+          guiding_factor: 0.9
+          learning_rate: 0.01
+          steps: 1000
+          var_schedule_start: 0.0001
+          var_schedule_end: 0.02
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_diffusion_model/loss.csv
-      md5: ac93ddd973e524f5e2324a24eac6aece
-      size: 245
+      hash: md5
+      md5: 343c82982cb714c9ee71917ed2710075
+      size: 473
     - path: outs/train_diffusion_model/model.pt
-      md5: f0faa6c6a1d9121cea100b16b5c3bd09
-      size: 54153325
+      hash: md5
+      md5: 566687a92263dc46f86f80036b43a106
+      size: 58599465
   draw_samples:
-    cmd: python logo_maker/probe_model.py --use_gpu --n_samples 64
+    cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
     - path: outs/train_autoencoder/model.pt
-      md5: b205f79b4d6d26f5730e630af8d80e9e
-      size: 3477013
+      hash: md5
+      md5: 7b9709dcb5c1affd0bb29c83fe120225
+      size: 18705937
     - path: outs/train_diffusion_model/model.pt
-      md5: f0faa6c6a1d9121cea100b16b5c3bd09
-      size: 54153325
+      hash: md5
+      md5: 566687a92263dc46f86f80036b43a106
+      size: 58599465
+    params:
+      params.yaml:
+        dataset:
+          name: MNIST
+          n_images: 128
+          shuffle: true
   train_autoencoder_lld:
     cmd: python favicon_gen/autoencoder.py
     deps:

--- a/dvc.lock
+++ b/dvc.lock
@@ -71,32 +71,32 @@ stages:
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      favicon_gen/params.py:
-        AutoEncoder:
+      params.yaml:
+        autoencoder:
           adversarial_loss_weight: 1.0
           batch_size: 512
-          epochs_mnist: 35
-          epochs_lld: 350
-          kl_loss_weight: 1
+          epochs_mnist: 20
+          epochs_lld: 200
+          kl_loss_weight: 1.0
           learning_rate: 0.0004
-        DO_NORM: true
-        Dataset:
+        dataset:
           specific_clusters:
           - 0
-          - 1
-          - 2
-          n_images:
+          n_images: 128
           shuffle: true
-        EMBEDDING_DIM: 32
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_autoencoder_lld/loss.csv
       hash: md5
-      md5: e5a2d2b580dae6e13fe52f9bdc56710e
-      size: 8260
+      md5: c095212bf46ae8b486f16eb221871951
+      size: 4686
     - path: outs/train_autoencoder_lld/model.pt
       hash: md5
-      md5: fd884c1f770b1bdc10014c55f8b92e90
-      size: 18708753
+      md5: b63e2fcf45016fe2ff5bc1a235cb11f2
+      size: 18708497
   train_autoencoder_mnist:
     cmd: python favicon_gen/autoencoder.py --use_mnist
     deps:
@@ -105,31 +105,31 @@ stages:
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      favicon_gen/params.py:
-        AutoEncoder:
+      params.yaml:
+        autoencoder:
           adversarial_loss_weight: 1.0
           batch_size: 512
-          epochs_mnist: 35
-          epochs_lld: 350
-          kl_loss_weight: 1
+          epochs_mnist: 20
+          epochs_lld: 200
+          kl_loss_weight: 1.0
           learning_rate: 0.0004
-        DO_NORM: true
-        Dataset:
+        dataset:
           specific_clusters:
           - 0
-          - 1
-          - 2
-          n_images:
+          n_images: 128
           shuffle: true
-        EMBEDDING_DIM: 32
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_autoencoder_mnist/loss.csv
       hash: md5
-      md5: 1788f4fe95f55e56f6f9ec2aa36c374d
-      size: 812
+      md5: 31f2c0f5bad7baa78a03d877baacb29a
+      size: 459
     - path: outs/train_autoencoder_mnist/model.pt
       hash: md5
-      md5: d5d78c3434a77881b8729526bdab8204
+      md5: c2e687fa031dba17ef40254db917a3bb
       size: 18705937
   draw_samples_mnist:
     cmd: python favicon_gen/sample_from_model.py --use_mnist --use_gpu --n_samples
@@ -137,23 +137,23 @@ stages:
     deps:
     - path: outs/train_autoencoder_mnist/model.pt
       hash: md5
-      md5: d5d78c3434a77881b8729526bdab8204
+      md5: c2e687fa031dba17ef40254db917a3bb
       size: 18705937
     - path: outs/train_diffusion_model_mnist/model.pt
       hash: md5
-      md5: e5ab7800229b9323457ff01466bdcabf
+      md5: ea1264dfba0645b41a75ec9689de5c6e
       size: 58599465
   draw_samples_lld:
     cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
     - path: outs/train_autoencoder_lld/model.pt
       hash: md5
-      md5: fd884c1f770b1bdc10014c55f8b92e90
-      size: 18708753
+      md5: b63e2fcf45016fe2ff5bc1a235cb11f2
+      size: 18708497
     - path: outs/train_diffusion_model_lld/model.pt
       hash: md5
-      md5: 21d2f1d6f2fff0cef2e1e27483582d7d
-      size: 58607529
+      md5: 7785b32060090ef63ded457db404bdb3
+      size: 58607273
   train_diffusion_model_mnist:
     cmd: python favicon_gen/denoising_diffusion.py --use_mnist
     deps:
@@ -162,33 +162,33 @@ stages:
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      favicon_gen/params.py:
-        DO_NORM: true
-        Dataset:
+      params.yaml:
+        dataset:
           specific_clusters:
           - 0
-          - 1
-          - 2
-          n_images:
+          n_images: 128
           shuffle: true
-        Diffusion:
-          batch_size: 512
-          epochs_mnist: 35
-          epochs_lld: 250
+        diffusion:
+          batch_size: 32
+          epochs_mnist: 20
+          epochs_lld: 201
           guiding_factor: 0.9
-          learning_rate: 0.001
+          learning_rate: 0.01
           steps: 1000
           var_schedule_start: 0.0001
           var_schedule_end: 0.02
-        EMBEDDING_DIM: 32
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_diffusion_model_mnist/loss.csv
       hash: md5
-      md5: debad67760818d04c6a21d9b6a23a7d0
-      size: 851
+      md5: c45451d179f1b16a472656dfb4adf6c7
+      size: 463
     - path: outs/train_diffusion_model_mnist/model.pt
       hash: md5
-      md5: e5ab7800229b9323457ff01466bdcabf
+      md5: ea1264dfba0645b41a75ec9689de5c6e
       size: 58599465
   train_diffusion_model_lld:
     cmd: python favicon_gen/denoising_diffusion.py
@@ -198,31 +198,31 @@ stages:
       md5: 91f56af2235117e44629fa608fed59ef
       size: 798927457
     params:
-      favicon_gen/params.py:
-        DO_NORM: true
-        Dataset:
+      params.yaml:
+        dataset:
           specific_clusters:
           - 0
-          - 1
-          - 2
-          n_images:
+          n_images: 128
           shuffle: true
-        Diffusion:
-          batch_size: 512
-          epochs_mnist: 35
-          epochs_lld: 250
+        diffusion:
+          batch_size: 32
+          epochs_mnist: 20
+          epochs_lld: 201
           guiding_factor: 0.9
-          learning_rate: 0.001
+          learning_rate: 0.01
           steps: 1000
           var_schedule_start: 0.0001
           var_schedule_end: 0.02
-        EMBEDDING_DIM: 32
+        general:
+          device: cuda
+          embedding_dim: 32
+          do_norm: true
     outs:
     - path: outs/train_diffusion_model_lld/loss.csv
       hash: md5
-      md5: 5216d6179898d9e3b88f20cc0fe08294
-      size: 6248
+      md5: f7c1cc4a9d3cb45c21f60abf19bc33a6
+      size: 4877
     - path: outs/train_diffusion_model_lld/model.pt
       hash: md5
-      md5: 21d2f1d6f2fff0cef2e1e27483582d7d
-      size: 58607529
+      md5: 7785b32060090ef63ded457db404bdb3
+      size: 58607273

--- a/dvc.lock
+++ b/dvc.lock
@@ -12,12 +12,16 @@ stages:
           adversarial_loss_weight: 1.0
           batch_size: 512
           epochs_mnist: 20
-          epochs_lld: 200
+          epochs_lld: 100
           kl_loss_weight: 1.0
           learning_rate: 0.0004
         dataset:
-          name: MNIST
-          n_images: 128
+          name: LLD
+          specific_clusters:
+          - 0
+          - 1
+          - 2
+          n_images:
           shuffle: true
         general:
           device: cuda
@@ -26,12 +30,12 @@ stages:
     outs:
     - path: outs/train_autoencoder/loss.csv
       hash: md5
-      md5: 36a45f9cdde04875f0f292a1e136d408
-      size: 458
+      md5: 2afcf15ace22f56b30beb565aed3feec
+      size: 2293
     - path: outs/train_autoencoder/model.pt
       hash: md5
-      md5: 7b9709dcb5c1affd0bb29c83fe120225
-      size: 18705937
+      md5: 8ecd7ba7a09263204f00470d8ce2fb19
+      size: 18708753
   train_diffusion_model:
     cmd: python favicon_gen/denoising_diffusion.py
     deps:
@@ -41,13 +45,17 @@ stages:
     params:
       params.yaml:
         dataset:
-          name: MNIST
-          n_images: 128
+          name: LLD
+          specific_clusters:
+          - 0
+          - 1
+          - 2
+          n_images:
           shuffle: true
         diffusion:
           batch_size: 32
           epochs_mnist: 20
-          epochs_lld: 201
+          epochs_lld: 100
           guiding_factor: 0.9
           learning_rate: 0.01
           steps: 1000
@@ -60,28 +68,32 @@ stages:
     outs:
     - path: outs/train_diffusion_model/loss.csv
       hash: md5
-      md5: 343c82982cb714c9ee71917ed2710075
-      size: 473
+      md5: ba04ec94ec32396e558222f2190de612
+      size: 2414
     - path: outs/train_diffusion_model/model.pt
       hash: md5
-      md5: 566687a92263dc46f86f80036b43a106
-      size: 58599465
+      md5: 956651012fd4d4018424a453a2d34710
+      size: 58607529
   draw_samples:
     cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
     - path: outs/train_autoencoder/model.pt
       hash: md5
-      md5: 7b9709dcb5c1affd0bb29c83fe120225
-      size: 18705937
+      md5: 8ecd7ba7a09263204f00470d8ce2fb19
+      size: 18708753
     - path: outs/train_diffusion_model/model.pt
       hash: md5
-      md5: 566687a92263dc46f86f80036b43a106
-      size: 58599465
+      md5: 956651012fd4d4018424a453a2d34710
+      size: 58607529
     params:
       params.yaml:
         dataset:
-          name: MNIST
-          n_images: 128
+          name: LLD
+          specific_clusters:
+          - 0
+          - 1
+          - 2
+          n_images:
           shuffle: true
   train_autoencoder_lld:
     cmd: python favicon_gen/autoencoder.py

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -6,11 +6,9 @@ stages:
     outs:
       - outs/train_autoencoder_mnist/model.pt
     params:
-      - favicon_gen/params.py:
-        - DO_NORM
-        - EMBEDDING_DIM
-        - AutoEncoder
-        - Dataset
+      - general
+      - autoencoder
+      - dataset
     plots:
       - outs/train_autoencoder_mnist/loss.csv:
           x: Epoch
@@ -23,11 +21,9 @@ stages:
     outs:
       - outs/train_autoencoder_lld/model.pt
     params:
-      - favicon_gen/params.py:
-          - DO_NORM
-          - EMBEDDING_DIM
-          - AutoEncoder
-          - Dataset
+      - general
+      - autoencoder
+      - dataset
     plots:
       - outs/train_autoencoder_lld/loss.csv:
           x: Epoch
@@ -40,11 +36,9 @@ stages:
     outs:
       - outs/train_diffusion_model_mnist/model.pt
     params:
-      - favicon_gen/params.py:
-        - DO_NORM
-        - EMBEDDING_DIM
-        - Dataset
-        - Diffusion
+      - general
+      - dataset
+      - diffusion
     plots:
       - outs/train_diffusion_model_mnist/loss.csv:
           x: Epoch
@@ -57,11 +51,9 @@ stages:
     outs:
       - outs/train_diffusion_model_lld/model.pt
     params:
-      - favicon_gen/params.py:
-          - DO_NORM
-          - EMBEDDING_DIM
-          - Dataset
-          - Diffusion
+      - general
+      - dataset
+      - diffusion
     plots:
       - outs/train_diffusion_model_lld/loss.csv:
           x: Epoch

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -20,3 +20,6 @@ stages:
       - outs/model.pt
     params:
     - dataset
+
+metrics:
+  - outs/metrics.json

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,40 +1,22 @@
 stages:
-  train_autoencoder:
-    cmd: python favicon_gen/autoencoder.py
+  train_model:
+    cmd: python favicon_gen/call_training.py
     deps:
       - data/LLD-icon.hdf5
     outs:
-      - outs/train_autoencoder/model.pt
+      - outs/model.pt
     params:
       - general
-      - autoencoder
+      - model
       - dataset
     plots:
-      - outs/train_autoencoder/loss.csv:
-          x: Epoch
-          y: Loss
-
-
-  train_diffusion_model:
-    cmd: python favicon_gen/denoising_diffusion.py
-    deps:
-      - data/LLD-icon.hdf5
-    outs:
-      - outs/train_diffusion_model/model.pt
-    params:
-      - general
-      - dataset
-      - diffusion
-    plots:
-      - outs/train_diffusion_model/loss.csv:
+      - outs/loss.csv:
           x: Epoch
           y: Loss
 
   draw_samples:
     cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
-      - outs/train_autoencoder/model.pt
-      - outs/train_diffusion_model/model.pt
+      - outs/model.pt
     params:
     - dataset
-

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,74 +1,40 @@
 stages:
-  train_autoencoder_mnist:
-    cmd: python favicon_gen/autoencoder.py --use_mnist
-    deps:
-      - data/LLD-icon.hdf5
-    outs:
-      - outs/train_autoencoder_mnist/model.pt
-    params:
-      - general
-      - autoencoder
-      - dataset
-    plots:
-      - outs/train_autoencoder_mnist/loss.csv:
-          x: Epoch
-          y: Loss
-
-  train_autoencoder_lld:
+  train_autoencoder:
     cmd: python favicon_gen/autoencoder.py
     deps:
       - data/LLD-icon.hdf5
     outs:
-      - outs/train_autoencoder_lld/model.pt
+      - outs/train_autoencoder/model.pt
     params:
       - general
       - autoencoder
       - dataset
     plots:
-      - outs/train_autoencoder_lld/loss.csv:
+      - outs/train_autoencoder/loss.csv:
           x: Epoch
           y: Loss
 
-  train_diffusion_model_mnist:
-    cmd: python favicon_gen/denoising_diffusion.py --use_mnist
-    deps:
-      - data/LLD-icon.hdf5
-    outs:
-      - outs/train_diffusion_model_mnist/model.pt
-    params:
-      - general
-      - dataset
-      - diffusion
-    plots:
-      - outs/train_diffusion_model_mnist/loss.csv:
-          x: Epoch
-          y: Loss
 
-  train_diffusion_model_lld:
+  train_diffusion_model:
     cmd: python favicon_gen/denoising_diffusion.py
     deps:
       - data/LLD-icon.hdf5
     outs:
-      - outs/train_diffusion_model_lld/model.pt
+      - outs/train_diffusion_model/model.pt
     params:
       - general
       - dataset
       - diffusion
     plots:
-      - outs/train_diffusion_model_lld/loss.csv:
+      - outs/train_diffusion_model/loss.csv:
           x: Epoch
           y: Loss
 
-
-  draw_samples_mnist:
-    cmd: python favicon_gen/sample_from_model.py --use_mnist --use_gpu --n_samples 64
-    deps:
-      - outs/train_autoencoder_mnist/model.pt
-      - outs/train_diffusion_model_mnist/model.pt
-
-  draw_samples_lld:
+  draw_samples:
     cmd: python favicon_gen/sample_from_model.py --use_gpu --n_samples 64
     deps:
-      - outs/train_autoencoder_lld/model.pt
-      - outs/train_diffusion_model_lld/model.pt
+      - outs/train_autoencoder/model.pt
+      - outs/train_diffusion_model/model.pt
+    params:
+    - dataset
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,11 @@ dependencies:
   - dvc>=3
   - flake8=6
   - h5py>=3.7
+  - hydra
   - matplotlib>=3.7
   - mypy>=0.9
   - numpy>=1.25
+  - omegaconf
   - pip
   - pylint>=2.16
   - pytest>=7.3

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ channels:
 
 dependencies:
   - black=23
+  - dacite
   - dvc>=3
   - flake8=6
   - h5py>=3.7

--- a/favicon_gen/autoencoder.py
+++ b/favicon_gen/autoencoder.py
@@ -183,6 +183,7 @@ def train(
     :param dataset_params: Dataset parameters
     :param auto_params: Model parameters
     :param model_file: If given, will start from the model saved there
+    :return: Loss for each epoch
     """
     n_samples, data_loader = load_data(auto_params.batch_size, dataset_params)
     model_storage_directory = params.OUTS_BASE_DIR
@@ -270,7 +271,4 @@ def train(
     print(f"Saving model in directory {model_storage_directory} ...")
     torch.save(autoencoder.state_dict(), model_storage_directory / "model.pt")
 
-    with open(model_storage_directory / "loss.csv", "w", encoding="utf-8") as file:
-        file.write("Epoch,Loss\n")
-        for epoch, loss in enumerate(running_losses):
-            file.write(f"{epoch},{loss}\n")
+    return running_losses

--- a/favicon_gen/autoencoder.py
+++ b/favicon_gen/autoencoder.py
@@ -189,29 +189,27 @@ def train(
     match dataset_params.name:
         case params.AvailableDatasets.MNIST:
             n_epochs = auto_params.epochs_mnist
-            in_channels = 1
             use_mnist = True
         case params.AvailableDatasets.LLD:
             n_epochs = auto_params.epochs_lld
-            in_channels = 3
             use_mnist = False
 
     print(f"Cleaning output directory {model_storage_directory} ...")
     if model_storage_directory.exists():
         shutil.rmtree(model_storage_directory)
-    model_storage_directory.mkdir(exist_ok=True)
+    model_storage_directory.mkdir(exist_ok=True, parents=True)
 
     # prepare discriminator
     use_patch_discriminator = auto_params.adversarial_loss_weight is not None
     if use_patch_discriminator:
-        patch_disc = PatchDiscriminator(in_channels)
+        patch_disc = PatchDiscriminator(dataset_params.in_channels)
         patch_disc.to(general_params.device)
         lower_disc_learning_rate = 0.1 * auto_params.learning_rate  # lower rate helps in GAN training
         optimizer_discriminator = torch.optim.Adam(patch_disc.parameters(), lr=lower_disc_learning_rate)
 
     # prepare autoencoder
     n_labels = get_number_of_different_labels(use_mnist, dataset_params.specific_clusters)
-    autoencoder = VariationalAutoEncoder(in_channels, n_labels, general_params.embedding_dim)
+    autoencoder = VariationalAutoEncoder(dataset_params.in_channels, n_labels, general_params.embedding_dim)
     if model_file is not None:
         autoencoder.load_state_dict(torch.load(model_file))
     autoencoder.to(general_params.device)

--- a/favicon_gen/autoencoder.py
+++ b/favicon_gen/autoencoder.py
@@ -185,7 +185,7 @@ def train(
     :param model_file: If given, will start from the model saved there
     """
     n_samples, data_loader = load_data(auto_params.batch_size, dataset_params)
-    model_storage_directory = params.OUTS_BASE_DIR / "train_autoencoder"
+    model_storage_directory = params.OUTS_BASE_DIR
     match dataset_params.name:
         case params.AvailableDatasets.MNIST:
             n_epochs = auto_params.epochs_mnist
@@ -274,8 +274,3 @@ def train(
         file.write("Epoch,Loss\n")
         for epoch, loss in enumerate(running_losses):
             file.write(f"{epoch},{loss}\n")
-
-
-if __name__ == "__main__":
-    config = params.load_config()
-    train(config.dataset, config.autoencoder, config.general)

--- a/favicon_gen/autoencoder.py
+++ b/favicon_gen/autoencoder.py
@@ -10,9 +10,9 @@ from typing import Any  # noqa: F401
 import torch
 from tqdm import tqdm
 
+from favicon_gen import params
 from favicon_gen.blocks import ConvBlock, ResampleModi
 from favicon_gen.data_loading import load_logos, load_mnist, show_image_grid, get_number_of_different_labels
-from favicon_gen import params
 
 
 class Encoder(torch.nn.Module):
@@ -90,11 +90,10 @@ class VariationalAutoEncoder(torch.nn.Module):
     :param n_labels: Amount of different labels in the data (e.g. 10 for the 10 different digits in MNIST)
     """
 
-    def __init__(self, in_channels: int, n_labels: int) -> None:
+    def __init__(self, in_channels: int, n_labels: int, embedding_dim: int) -> None:
         super().__init__()
         self.latent_dim = 512
         self.activation = torch.nn.LeakyReLU()
-        embedding_dim = params.EMBEDDING_DIM
         self.label_embedding = torch.nn.Embedding(n_labels, embedding_dim)
 
         self.encoder = Encoder(in_channels, self.activation)
@@ -174,29 +173,33 @@ class PatchDiscriminator(torch.nn.Module):
 
 
 def train(
-    dataset_info: params.Dataset,
-    auto_info: params.AutoEncoder,
+    dataset_params: params.Dataset,
+    auto_params: params.AutoEncoder,
+    general_params: params.General,
     use_mnist: bool,
     model_file: Path | None = None,
 ) -> None:
     """
     Training loop for VAE or VAE + adversarial patch discriminator.
 
-    :param dataset_info: Dataset parameters
-    :param auto_info: Model parameters
+    :param dataset_params: Dataset parameters
+    :param auto_params: Model parameters
     :param use_mnist: Whether to use MNIST (`True`) or LLD (`False`) as training data
     :param model_file: If given, will start from the model saved there
     """
     if use_mnist:
-        n_samples, data_loader = load_mnist(auto_info.batch_size, dataset_info.shuffle, dataset_info.n_images)
-        n_epochs = auto_info.epochs_mnist
+        n_samples, data_loader = load_mnist(auto_params.batch_size, dataset_params.shuffle, dataset_params.n_images)
+        n_epochs = auto_params.epochs_mnist
         model_storage_directory = params.OUTS_BASE_DIR / "train_autoencoder_mnist"
         in_channels = 1
     else:
         n_samples, data_loader = load_logos(
-            auto_info.batch_size, dataset_info.shuffle, dataset_info.n_images, clusters=dataset_info.specific_clusters
+            auto_params.batch_size,
+            dataset_params.shuffle,
+            dataset_params.n_images,
+            clusters=dataset_params.specific_clusters,
         )
-        n_epochs = auto_info.epochs_lld
+        n_epochs = auto_params.epochs_lld
         model_storage_directory = params.OUTS_BASE_DIR / "train_autoencoder_lld"
         in_channels = 3
 
@@ -206,31 +209,33 @@ def train(
     model_storage_directory.mkdir(exist_ok=True)
 
     # prepare discriminator
-    use_patch_discriminator = auto_info.adversarial_loss_weight is not None
+    use_patch_discriminator = auto_params.adversarial_loss_weight is not None
     if use_patch_discriminator:
         patch_disc = PatchDiscriminator(in_channels)
-        patch_disc.to(params.DEVICE)
-        lower_disc_learning_rate = 0.1 * auto_info.learning_rate  # lower rate helps in GAN training
+        patch_disc.to(general_params.device)
+        lower_disc_learning_rate = 0.1 * auto_params.learning_rate  # lower rate helps in GAN training
         optimizer_discriminator = torch.optim.Adam(patch_disc.parameters(), lr=lower_disc_learning_rate)
 
     # prepare autoencoder
-    n_labels = get_number_of_different_labels(use_mnist, dataset_info.specific_clusters)
-    autoencoder = VariationalAutoEncoder(in_channels, n_labels)
+    n_labels = get_number_of_different_labels(use_mnist, dataset_params.specific_clusters)
+    autoencoder = VariationalAutoEncoder(in_channels, n_labels, general_params.embedding_dim)
     if model_file is not None:
         autoencoder.load_state_dict(torch.load(model_file))
-    autoencoder.to(params.DEVICE)
-    optimizer_generator = torch.optim.Adam(autoencoder.parameters(), lr=auto_info.learning_rate)
+    autoencoder.to(general_params.device)
+    optimizer_generator = torch.optim.Adam(autoencoder.parameters(), lr=auto_params.learning_rate)
     loss_fn = torch.nn.MSELoss()
 
     running_losses = []
     running_loss = 0
-    value_for_original = torch.tensor([1], device=params.DEVICE, dtype=torch.float)
-    value_for_reconstructed = torch.tensor([0], device=params.DEVICE, dtype=torch.float)
+    value_for_original = torch.tensor([1], device=general_params.device, dtype=torch.float)
+    value_for_reconstructed = torch.tensor([0], device=general_params.device, dtype=torch.float)
     for epoch in (pbar := tqdm(range(n_epochs), desc="Current avg. loss: /, Epochs")):
         batch: torch.Tensor
         for batch, labels in data_loader:
-            labels = labels.to(params.DEVICE)
-            batch = batch.to(params.DEVICE)  # batch does not track gradients -> does not need to be detached ever
+            labels = labels.to(general_params.device)
+            batch = batch.to(
+                general_params.device
+            )  # batch does not track gradients -> does not need to be detached ever
 
             optimizer_generator.zero_grad()
             reconst_batch, mu, log_var = autoencoder(batch, labels)
@@ -241,12 +246,12 @@ def train(
                 is_original = torch.broadcast_to(value_for_original, disc_pred_reconstructed.shape)
                 is_reconstructed = torch.broadcast_to(value_for_reconstructed, disc_pred_reconstructed.shape)
                 adversarial_loss = torch.nn.L1Loss()(disc_pred_reconstructed, is_original)
-                adversarial_loss_weight = auto_info.adversarial_loss_weight
+                adversarial_loss_weight = auto_params.adversarial_loss_weight
             else:
                 adversarial_loss = 0
                 adversarial_loss_weight = 0
             generator_loss = (
-                reconstruction_loss + auto_info.kl_loss_weight * kl_loss + adversarial_loss_weight * adversarial_loss
+                reconstruction_loss + auto_params.kl_loss_weight * kl_loss + adversarial_loss_weight * adversarial_loss
             )
             generator_loss.backward()
             optimizer_generator.step()
@@ -287,4 +292,5 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    train(dataset_info=params.Dataset(), auto_info=params.AutoEncoder(), use_mnist=args.use_mnist)
+    config = params.load_config()
+    train(config.dataset, config.autoencoder, config.general, args.use_mnist)

--- a/favicon_gen/blocks.py
+++ b/favicon_gen/blocks.py
@@ -11,6 +11,8 @@ import torch
 
 from favicon_gen import params
 
+GENERAL_PARAMS = params.load_config().general
+
 
 class ResampleModi(Enum):
     """Possible resampling modi for convolutional block"""
@@ -47,8 +49,8 @@ class ConvBlock(torch.nn.Module):
         super().__init__()
         self.activation = activation
         self.resample_modus = resample_modus
-        embedding_dimension = params.EMBEDDING_DIM
-        norm_fn = torch.nn.LazyBatchNorm2d if params.DO_NORM else torch.nn.Identity
+        embedding_dimension = GENERAL_PARAMS.embedding_dim
+        norm_fn = torch.nn.LazyBatchNorm2d if GENERAL_PARAMS.do_norm else torch.nn.Identity
 
         self.conv_in: torch.nn.Conv2d | torch.nn.Identity
         self.conv_out: torch.nn.ConvTranspose2d | torch.nn.Identity

--- a/favicon_gen/call_training.py
+++ b/favicon_gen/call_training.py
@@ -1,0 +1,13 @@
+from favicon_gen import params
+from favicon_gen.denoising_diffusion import train as train_diffusion
+from favicon_gen.autoencoder import train as train_autoencoder
+
+
+if __name__ == "__main__":
+    config = params.load_config()
+
+    match config.model:
+        case params.AutoEncoder():
+            train_autoencoder(config.dataset, config.model, config.general)
+        case params.Diffusion():
+            train_diffusion(config.dataset, config.model, config.general)

--- a/favicon_gen/call_training.py
+++ b/favicon_gen/call_training.py
@@ -1,3 +1,5 @@
+import json
+
 from favicon_gen import params
 from favicon_gen.denoising_diffusion import train as train_diffusion
 from favicon_gen.autoencoder import train as train_autoencoder
@@ -8,6 +10,14 @@ if __name__ == "__main__":
 
     match config.model:
         case params.AutoEncoder():
-            train_autoencoder(config.dataset, config.model, config.general)
+            running_losses = train_autoencoder(config.dataset, config.model, config.general)
         case params.Diffusion():
-            train_diffusion(config.dataset, config.model, config.general)
+            running_losses = train_diffusion(config.dataset, config.model, config.general)
+
+    with open(params.OUTS_BASE_DIR / "loss.csv", "w", encoding="utf-8") as file:
+        file.write("Epoch,Loss\n")
+        for epoch, loss in enumerate(running_losses):
+            file.write(f"{epoch},{loss}\n")
+
+    with open(params.OUTS_BASE_DIR / "metrics.json", "w", encoding="utf-8") as file:
+        json.dump({"final_loss": running_losses[-1]}, file)

--- a/favicon_gen/compose_params_yaml.py
+++ b/favicon_gen/compose_params_yaml.py
@@ -1,0 +1,21 @@
+"""
+Explicitly compose a params.yaml from
+the hydra config files stored in the 'conf'
+folder. 
+For some reason DVC does not come with this 
+functionality outside of using 'dvc exp run'.
+"""
+
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+
+from favicon_gen.params import REPO_ROOT
+
+
+if __name__ == "__main__":
+    # context initialization
+    with initialize(version_base=None, config_path="../conf", job_name="test_app"):
+        cfg = compose(config_name="config")
+
+    with open(REPO_ROOT / "params.yaml", "w", encoding="utf-8") as params_yaml:
+        OmegaConf.save(config=cfg, f=params_yaml.name)

--- a/favicon_gen/data_loading.py
+++ b/favicon_gen/data_loading.py
@@ -161,6 +161,16 @@ def load_mnist(batch_size: int, shuffle: bool, n_images: int | None) -> tuple[in
     return len(mnist), loader
 
 
+def load_data(batch_size: int, dataset_params: params.Dataset):
+    match dataset_params.name:
+        case params.AvailableDatasets.MNIST:
+            return load_mnist(batch_size, dataset_params.shuffle, dataset_params.n_images)
+        case params.AvailableDatasets.LLD:
+            return load_logos(
+                batch_size, dataset_params.shuffle, dataset_params.n_images, dataset_params.specific_clusters
+            )
+
+
 def get_number_of_different_labels(use_mnist: bool, clusters: list[int] | None) -> int:
     """
     Get amount of different labels (e.g. 10 for the ten digits in MNIST).

--- a/favicon_gen/data_loading.py
+++ b/favicon_gen/data_loading.py
@@ -18,7 +18,6 @@ from torchvision import datasets, transforms, utils
 
 from favicon_gen import params
 
-
 FORWARD_TRANSFORMS = transforms.Compose(
     [transforms.ToTensor(), transforms.Lambda(lambda t: (t * 2) - 1)]  # Scale between [-1, 1]
 )

--- a/favicon_gen/denoising_diffusion.py
+++ b/favicon_gen/denoising_diffusion.py
@@ -250,10 +250,8 @@ def train(
     model_storage_directory = params.OUTS_BASE_DIR / "train_diffusion_model"
     match dataset_info.name:
         case params.AvailableDatasets.MNIST:
-            in_channels = 1
             use_mnist = True
         case params.AvailableDatasets.LLD:
-            in_channels = 3
             use_mnist = False
 
     print(f"Cleaning output directory {model_storage_directory} ...")
@@ -267,7 +265,7 @@ def train(
     )
 
     n_labels = get_number_of_different_labels(use_mnist, dataset_info.specific_clusters)
-    model = DiffusionModel(in_channels, schedule, n_labels, general_params.embedding_dim)
+    model = DiffusionModel(dataset_info.in_channels, schedule, n_labels, general_params.embedding_dim)
     if model_file is not None:
         model.load_state_dict(torch.load(model_file))
     model.to(general_params.device)

--- a/favicon_gen/denoising_diffusion.py
+++ b/favicon_gen/denoising_diffusion.py
@@ -237,13 +237,14 @@ def train(
     diffusion_info: params.Diffusion,
     general_params: params.General,
     model_file: Path | None = None,
-) -> None:
+) -> np.ndarray:
     """
     Training loop for diffusion model.
 
     :param dataset_info: Dataset parameters
     :param diffusion_info: Model parameters
     :param model_file: If given, will start from the model saved there
+    :return: Loss for each epoch
     """
 
     n_samples, data_loader = load_data(diffusion_info.batch_size, dataset_info)
@@ -314,7 +315,4 @@ def train(
 
     torch.save(model.state_dict(), model_storage_directory / "model.pt")
 
-    with open(model_storage_directory / "loss.csv", "w", encoding="utf-8") as file:
-        file.write("Epoch,Loss\n")
-        for epoch, loss in enumerate(running_losses):
-            file.write(f"{epoch},{loss}\n")
+    return running_losses

--- a/favicon_gen/denoising_diffusion.py
+++ b/favicon_gen/denoising_diffusion.py
@@ -247,7 +247,7 @@ def train(
     """
 
     n_samples, data_loader = load_data(diffusion_info.batch_size, dataset_info)
-    model_storage_directory = params.OUTS_BASE_DIR / "train_diffusion_model"
+    model_storage_directory = params.OUTS_BASE_DIR
     match dataset_info.name:
         case params.AvailableDatasets.MNIST:
             use_mnist = True
@@ -318,8 +318,3 @@ def train(
         file.write("Epoch,Loss\n")
         for epoch, loss in enumerate(running_losses):
             file.write(f"{epoch},{loss}\n")
-
-
-if __name__ == "__main__":
-    config = params.load_config()
-    train(config.dataset, config.diffusion, config.general)

--- a/favicon_gen/params.py
+++ b/favicon_gen/params.py
@@ -1,41 +1,63 @@
 """
 Parameters used throughout the project
 """
-
+from dataclasses import dataclass
+from typing import Optional
 from pathlib import Path
+
+from omegaconf import OmegaConf
 
 
 REPO_ROOT = Path(__file__).parents[1]
 DATA_BASE_DIR = REPO_ROOT / "data"
 OUTS_BASE_DIR = REPO_ROOT / "outs"
 
-DEVICE: str = "cuda"  # whether to run on GPU ("cuda") or CPU ("cpu")
 
-EMBEDDING_DIM: int = 32  # dimension class labels and/or time step are transformed to
-DO_NORM: bool = True  # whether to perform batch norm
+@dataclass
+class General:
+    device: str # whether to run on GPU ("cuda") or CPU ("cpu")
+    embedding_dim: int  # dimension class labels and/or time step are transformed to
+    do_norm: bool # whether to perform batch norm
 
 
+@dataclass
 class Dataset:  # everything related to MNIST/LLD
-    specific_clusters: list[int] | None = [0, 1, 2]  # which LLD clusters to use; ignored for MNIST
-    n_images: int | None = None  # total amount of images to load, None means all of them
-    shuffle = True  # whether to shuffle the data
+    specific_clusters: Optional[list[int]] # which LLD clusters to use; ignored for MNIST
+    n_images: Optional[int]  # total amount of images to load, None means all of them
+    shuffle: bool  # whether to shuffle the data
 
 
+@dataclass
 class AutoEncoder:  # everything related to VAE training
-    adversarial_loss_weight: float | None = 1.0  # if given, use weighted patch discriminator as adversary;
-    batch_size: int = 512
-    epochs_mnist: int = 35  # epochs to train on MNIST
-    epochs_lld: int = 350  # epochs to train on LLD
-    kl_loss_weight: float = 1  # weight of Kullback Leibler vs. reconstruction loss for VAE
-    learning_rate: float = 4e-4  # learning rate for VAE
+    adversarial_loss_weight: Optional[float]
+    batch_size: int
+    epochs_mnist: int  # epochs to train on MNIST
+    epochs_lld: int  # epochs to train on LLD
+    kl_loss_weight: float  # weight of Kullback Leibler vs. reconstruction loss for VAE
+    learning_rate: float  # learning rate for VAE
 
 
+@dataclass
 class Diffusion:  # everything related to diffusion model training
-    batch_size: int = 512
-    epochs_mnist: int = 35  # epochs to train on MNIST
-    epochs_lld: int = 250  # epochs to train on LLD
-    guiding_factor: float = 0.90  # Guided (with label) vs. unguided (without labels) in classifier free guidance [4]
-    learning_rate: float = 1e-3
-    steps: int = 1000  # amount of time steps the diffusion model uses
-    var_schedule_start: float = 0.0001  # starting value of the variance schedule beta
-    var_schedule_end: float = 0.02  # final value (after `Diffusion.steps` time steps) of the variance schedule beta
+    batch_size: int
+    epochs_mnist: int  # epochs to train on MNIST
+    epochs_lld: int  # epochs to train on LLD
+    guiding_factor: float  # Guided (with label) vs. unguided (without labels) in classifier free guidance [4]
+    learning_rate: float
+    steps: int # amount of time steps the diffusion model uses
+    var_schedule_start: float # starting value of the variance schedule beta
+    var_schedule_end: float  # final value (after `Diffusion.steps` time steps) of the variance schedule beta
+
+
+@dataclass
+class ProjectConfig:
+    general: General
+    dataset: Dataset
+    autoencoder: AutoEncoder
+    diffusion: Diffusion
+
+
+def load_config() -> ProjectConfig:
+    schema = OmegaConf.structured(ProjectConfig)
+    cfg = OmegaConf.merge(schema, OmegaConf.load("params.yaml"))
+    return cfg

--- a/favicon_gen/params.py
+++ b/favicon_gen/params.py
@@ -2,6 +2,7 @@
 Parameters used throughout the project
 """
 from dataclasses import dataclass
+from enum import auto, Enum
 from typing import Optional
 from pathlib import Path
 
@@ -20,11 +21,17 @@ class General:
     do_norm: bool # whether to perform batch norm
 
 
+class AvailableDatasets(Enum):
+    LLD = auto()
+    MNIST = auto()
+
+
 @dataclass
 class Dataset:  # everything related to MNIST/LLD
-    specific_clusters: Optional[list[int]] # which LLD clusters to use; ignored for MNIST
+    name: AvailableDatasets
     n_images: Optional[int]  # total amount of images to load, None means all of them
     shuffle: bool  # whether to shuffle the data
+    specific_clusters: Optional[list[int]] = None  # which LLD clusters to use
 
 
 @dataclass

--- a/favicon_gen/params.py
+++ b/favicon_gen/params.py
@@ -6,6 +6,7 @@ from enum import auto, Enum
 from typing import Optional
 from pathlib import Path
 
+from dacite import from_dict
 from omegaconf import OmegaConf
 
 
@@ -22,8 +23,8 @@ class General:
 
 
 class AvailableDatasets(Enum):
-    LLD = auto()
-    MNIST = auto()
+    LLD = auto()  # Large Logo Dataset
+    MNIST = auto()  # Modified National Institute of Standards and Technology database
 
 
 @dataclass
@@ -32,6 +33,14 @@ class Dataset:  # everything related to MNIST/LLD
     n_images: Optional[int]  # total amount of images to load, None means all of them
     shuffle: bool  # whether to shuffle the data
     specific_clusters: Optional[list[int]] = None  # which LLD clusters to use
+
+    @property
+    def in_channels(self):
+        match self.name:
+            case AvailableDatasets.LLD:
+                return 3
+            case AvailableDatasets.MNIST:
+                return 1
 
 
 @dataclass
@@ -67,4 +76,5 @@ class ProjectConfig:
 def load_config() -> ProjectConfig:
     schema = OmegaConf.structured(ProjectConfig)
     cfg = OmegaConf.merge(schema, OmegaConf.load("params.yaml"))
-    return cfg
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+    return from_dict(data_class=ProjectConfig, data=cfg_dict)

--- a/favicon_gen/sample_from_model.py
+++ b/favicon_gen/sample_from_model.py
@@ -3,6 +3,7 @@ Draw samples from both the diffusion model and the VAE
 """
 
 import argparse
+import copy
 from pathlib import Path
 import typing
 
@@ -11,7 +12,7 @@ import torch
 from tqdm import tqdm
 
 from favicon_gen.autoencoder import VariationalAutoEncoder
-from favicon_gen.data_loading import show_image_grid, load_logos, load_mnist, get_number_of_different_labels
+from favicon_gen.data_loading import show_image_grid, load_data, get_number_of_different_labels
 from favicon_gen.denoising_diffusion import DiffusionModel, diffusion_backward_process, VarianceSchedule
 from favicon_gen import params
 
@@ -104,7 +105,6 @@ def sample_from_diffusion_model(
 def nearest_neighbor_search(
     generated_batch: torch.Tensor,
     dataset_info: params.Dataset,
-    use_mnist: bool,
     save_as: Path | None = None,
 ) -> torch.Tensor:
     """
@@ -116,10 +116,9 @@ def nearest_neighbor_search(
     :param save_as: Save image of the batch of nearest neighbors here
     :return: batch of nearest neighbors
     """
-    if use_mnist:
-        _, data_loader = load_mnist(1, False, dataset_info.n_images)
-    else:
-        _, data_loader = load_logos(1, False, dataset_info.n_images, dataset_info.specific_clusters)
+    modified_dataset_info = copy.deepcopy(dataset_info)
+    modified_dataset_info.shuffle = False
+    _, data_loader = load_data(1, modified_dataset_info)
 
     nearest_neighbors = torch.zeros(generated_batch.shape, device=generated_batch.device)
     current_nearest_neighbor_distances = torch.full(
@@ -146,9 +145,6 @@ def main():
     parser = argparse.ArgumentParser(description="Get sample images from models")
     parser.add_argument("--n_samples", type=int, default=64, help="Number of samples to get from model.")
     parser.add_argument("--use_gpu", help="Try to calculate on GPU.", action="store_true")
-    parser.add_argument(
-        "--use_mnist", action="store_true", help="Whether to train on MNIST instead of the Large Logo Dataset."
-    )
 
     args = parser.parse_args()
     if args.use_gpu:
@@ -156,22 +152,26 @@ def main():
     else:
         device = "cpu"
 
-    if args.use_mnist:
-        model_file_auto = params.OUTS_BASE_DIR / "train_autoencoder_mnist/model.pt"
+    config = params.load_config()
+    match config.dataset.name:
+        case params.AvailableDatasets.MNIST:
+            in_channels = 1
+            use_mnist = True
+        case params.AvailableDatasets.LLD:
+            in_channels = 3
+            use_mnist = False
+
+
+    model_file_auto = params.OUTS_BASE_DIR / "train_autoencoder/model.pt"
+    model_file_diffusion = params.OUTS_BASE_DIR / "train_diffusion_model/model.pt"
+    if use_mnist:
         save_location_auto_samples = params.OUTS_BASE_DIR / "samples_autoencoder_mnist.pdf"
-        model_file_diffusion = params.OUTS_BASE_DIR / "train_diffusion_model_mnist/model.pt"
         save_location_diff_samples = params.OUTS_BASE_DIR / "samples_diffusion_mnist.pdf"
     else:
-        model_file_auto = params.OUTS_BASE_DIR / "train_autoencoder_lld/model.pt"
         save_location_auto_samples = params.OUTS_BASE_DIR / "samples_autoencoder_lld.pdf"
-        model_file_diffusion = params.OUTS_BASE_DIR / "train_diffusion_model_lld/model.pt"
         save_location_diff_samples = params.OUTS_BASE_DIR / "samples_diffusion_lld.pdf"
 
-    config = params.load_config()
-
-    in_channels = 1 if args.use_mnist else 3
-    n_labels = get_number_of_different_labels(args.use_mnist, config.dataset.specific_clusters)
-
+    n_labels = get_number_of_different_labels(use_mnist, config.dataset.specific_clusters)
 
     auto_gen_batch = next(
         sample_from_vae(
@@ -200,15 +200,13 @@ def main():
     nearest_neighbor_search(
         auto_gen_batch,
         config.dataset,
-        args.use_mnist,
-        save_as=params.OUTS_BASE_DIR / f"auto_nearest_neighbors_mnist_{args.use_mnist}.pdf",
+        save_as=params.OUTS_BASE_DIR / f"auto_nearest_neighbors_mnist_{use_mnist}.pdf",
     )
 
     nearest_neighbor_search(
         diffusion_gen_batch,
         config.dataset,
-        args.use_mnist,
-        save_as=params.OUTS_BASE_DIR / f"diffusion_nearest_neighbors_mnist_{args.use_mnist}.pdf",
+        save_as=params.OUTS_BASE_DIR / f"diffusion_nearest_neighbors_mnist_{use_mnist}.pdf",
     )
 
 

--- a/params.yaml
+++ b/params.yaml
@@ -6,23 +6,16 @@ dataset:
   - 2
   n_images: null
   shuffle: true
-general:
-  device: cuda
-  embedding_dim: 32
-  do_norm: true
-autoencoder:
-  adversarial_loss_weight: 1.0
-  batch_size: 512
-  epochs_mnist: 20
-  epochs_lld: 100
-  kl_loss_weight: 1.0
-  learning_rate: 0.0004
-diffusion:
+model:
   batch_size: 32
   epochs_mnist: 20
-  epochs_lld: 100
+  epochs_lld: 10
   guiding_factor: 0.9
   learning_rate: 0.01
   steps: 1000
   var_schedule_start: 0.0001
   var_schedule_end: 0.02
+general:
+  device: cuda
+  embedding_dim: 32
+  do_norm: true

--- a/params.yaml
+++ b/params.yaml
@@ -1,0 +1,25 @@
+general:
+  device: cuda
+  embedding_dim: 32
+  do_norm: true
+dataset:
+  specific_clusters:
+  - 0
+  n_images: 128
+  shuffle: true
+autoencoder:
+  adversarial_loss_weight: 1.0
+  batch_size: 512
+  epochs_mnist: 20
+  epochs_lld: 200
+  kl_loss_weight: 1.0
+  learning_rate: 0.0004
+diffusion:
+  batch_size: 32
+  epochs_mnist: 20
+  epochs_lld: 201
+  guiding_factor: 0.9
+  learning_rate: 0.01
+  steps: 1000
+  var_schedule_start: 0.0001
+  var_schedule_end: 0.02

--- a/params.yaml
+++ b/params.yaml
@@ -1,12 +1,11 @@
+dataset:
+  name: MNIST
+  n_images: 128
+  shuffle: true
 general:
   device: cuda
   embedding_dim: 32
   do_norm: true
-dataset:
-  specific_clusters:
-  - 0
-  n_images: 128
-  shuffle: true
 autoencoder:
   adversarial_loss_weight: 1.0
   batch_size: 512

--- a/params.yaml
+++ b/params.yaml
@@ -1,6 +1,10 @@
 dataset:
-  name: MNIST
-  n_images: 128
+  name: LLD
+  specific_clusters:
+  - 0
+  - 1
+  - 2
+  n_images: null
   shuffle: true
 general:
   device: cuda
@@ -10,13 +14,13 @@ autoencoder:
   adversarial_loss_weight: 1.0
   batch_size: 512
   epochs_mnist: 20
-  epochs_lld: 200
+  epochs_lld: 100
   kl_loss_weight: 1.0
   learning_rate: 0.0004
 diffusion:
   batch_size: 32
   epochs_mnist: 20
-  epochs_lld: 201
+  epochs_lld: 100
   guiding_factor: 0.9
   learning_rate: 0.01
   steps: 1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ ignored-modules = ["numpy", "torch"]
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+pythonpath = "."

--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,10 @@
 ## Introduction
 This is just a small side project of mine to try to generate logos
 (to be precise favicons = favorite + icon) with pytorch on my home
-computer. 
+computer.
 
 While the results are not terribly impressive, the diversity of images that
-even the small diffusion model used here can generate is quite astounding. 
+even the small diffusion model used here can generate is quite astounding.
 With some tuning, better results are certainly possible (especially if you
 have a newer GPU than my aging 1070Ti).
 
@@ -23,34 +23,34 @@ Note: If you do not have an Nvidia GPU, this will probably not work.
    place it in the `FaviconGen\data` directory (if the directory does not exist create it).
 4. Run ```set PYTHONPATH=%cd%``` in your conda prompt to add the `FaviconGen` directory to you
    PYTHONPATH.
-5. Running ```dvc repro``` should now train both a Variational AutoEncoder (VAE) and a denoising 
-   diffusion model and generate some images. This can take quite a while (you may want to reduce the 
-   amount of epochs in the `FavcionGen\favicon_gen\params.py` file before running the command to make
-   sure everything works). If the estimated time is extremely long (as in >several hours), you may want to check
-   whether your GPU was recognized by pytorch. To do this, type `python` in the conda prompt with 
-   activated `favicon_gen`-environment and run
+5. You can configure by adjusting the *.yaml-files in the `./conf`-folder and running the
+   script `./favicon_gen/compose_params_yaml.py`, or by directly manipulating the `./params.yaml`
+   file.
+5. Running ```dvc repro``` should now train the selected model and generate some images.
+   This can take quite a while . If the estimated time is extremely long (as in >several hours),
+   you may want to check whether your GPU was recognized by pytorch. To do this, type `python` in
+   the conda prompt with activated `favicon_gen`-environment and run
    ```
    import torch
    print(torch.cuda.is_available())
    ```
-   
+
 ## (Short) Explanation
 Code for reading in the training datasets resides in `data_loading.py`. The models can
 be trained either with the Large Logo Database (LLD) dataset [[2]](#2) or the
 MNIST dataset [[8]](#8).
 
-The scripts `autoencoder.py` and `denoising_diffusion.py` implement convolutional neural
+The files `autoencoder.py` and `denoising_diffusion.py` implement convolutional neural
 networks for Variational Autoencoder (VAE) and a denoising diffusion model, respectively.
 For a quick overview of the model architectures, see [fig. 1](#fig_1) and [fig.2](#fig_2).
-You can change parameters for these two models within the `favicong_gen\params.py` parameter
-file.
+You can change parameters for these two models within the `./params.yaml` file.
 
 To learn more about diffusion models, I really recommend reading [[1]](#1), which is a
-lot more digestible when accompanied by some [educational YouTube videos](#Educational-Youtube-Videos). 
+lot more digestible when accompanied by some [educational YouTube videos](#Educational-Youtube-Videos).
 For more details on VAEs, I found [[5]](#5) quite helpful, though one can also find some
 helpful videos and web articles (e.g. [[6]](#6) and [[7]](#7)).
 
-Finally, the script `sample_from_model.py` draws samples from the different models for both MNIST and LLD.
+Finally, the script `sample_from_model.py` draws samples from the different models.
 It can also find the nearest neighbor of a generated image within the dataset, which is really helpful
 in judging whether the generated images are actually novel or just carbon copies of images already
 in the dataset.
@@ -59,7 +59,7 @@ in the dataset.
    <img src="images/vae_architecture.png" alt="Architecture of the variational autoencoder" width="600"/>
    <figcaption>
       <a id="fig_1">Figure 1:</a>Architecture of the VAE implemented in `favicon_gen/autoencoder.py` (without
-      adversarial patch discriminator).  
+      adversarial patch discriminator).
    </figcaption>
 </figure>
 
@@ -67,13 +67,13 @@ in the dataset.
    <img src="images/diffusion_architecture.png" alt="Architecture of the diffusion model" width="600"/>
    <figcaption>
       <a id="fig_2">Figure 2:</a>Architecture of the diffusion model implemented in
-      `favicon_gen/denoising_diffusion.py`.  
+      `favicon_gen/denoising_diffusion.py`.
    </figcaption>
 </figure>
 
 ## Educational YouTube videos
 Aside from the great [references](#References) on the subject, there are also some YouTube videos
-that helped me enormously. 
+that helped me enormously.
 
 Diffusion:
 - DeepFinder, ["Diffusion models from scratch in pytorch"](https://www.youtube.com/watch?v=a4Yfz2FxXiY&t=895s)
@@ -85,7 +85,7 @@ Variational Autoencoder:
 
 
 ## References
-<a id="1">[1]</a> 
+<a id="1">[1]</a>
 J. Ho, A. Jain, and P. Abbeel, "Denoising Diffusion Probabilistic Models" arXiv, 2020,
 [URL](http://arxiv.org/abs/2006.11239)
 
@@ -96,7 +96,7 @@ in 2018 IEEE/CVF Conference on Computer Vision and Pattern Recognition, 2018,
 pp. 5879–5888. DOI: 10.1109/CVPR.2018.00616.
 
 <a id="3">[3]</a>
-M. Saeed, "A Gentle Introduction to Positional Encoding in Transformer Models, Part 1" 
+M. Saeed, "A Gentle Introduction to Positional Encoding in Transformer Models, Part 1"
 Machine Learning Mastery, 2022, [URL](https://machinelearningmastery.com/a-gentle-introduction-to-positional-encoding-in-transformer-models-part-1/)
 
 <a id="4">[4]</a>
@@ -108,7 +108,7 @@ C. Doersch, "Tutorial on Variational Autoencoders" arXiv, 2021,
 [URL](http://arxiv.org/abs/1606.05908)
 
 <a id="6">[6]</a>
-W. Falcon, "Variational Autoencoder demystified with pytorch implementation" 
+W. Falcon, "Variational Autoencoder demystified with pytorch implementation"
 towards data science, 2020, [URL](https://towardsdatascience.com/variational-autoencoder-demystified-with-pytorch-implementation-3a06bee395ed)
 
 <a id="7">[7]</a>

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -14,7 +14,7 @@ def test_autoencoder_model_runs(device: str = "cpu"):
     random.seed(0)
     pseudo_batch = torch.rand((32, 3, 32, 32), device=device)
     pseudo_labels = torch.randint(0, 9, size=(32,), device=device)
-    model = ate.VariationalAutoEncoder(3, 32).to(device)
+    model = ate.VariationalAutoEncoder(3, 32, 32).to(device)
     _ = model(pseudo_batch, pseudo_labels)[0]
 
 

--- a/tests/test_denoising_diffusion.py
+++ b/tests/test_denoising_diffusion.py
@@ -94,7 +94,7 @@ def test_drawing_sample_from_module_runs():
     random.seed(0)
     n_time_steps = 20
     variance_schedule = ddi.VarianceSchedule(n_time_steps=n_time_steps, beta_start_end=(0.0001, 0.02))
-    model = ddi.DiffusionModel(3, variance_schedule, 10)
+    model = ddi.DiffusionModel(3, variance_schedule, 10, 32)
     _ = ddi.diffusion_backward_process(model, (4, 3, 32, 32), 0.9, seed=0)
 
 
@@ -104,5 +104,7 @@ def test_diffusion_model_runs(device: str = "cpu"):
     pseudo_batch = torch.rand((32, 3, 32, 32), device=device)
     pseudo_time_steps = torch.randint(0, 10, size=(32,), device=device)
     pseudo_labels = torch.randint(0, 9, size=(32,), device=device)
-    model = ddi.DiffusionModel(3, ddi.VarianceSchedule(n_time_steps=1000, beta_start_end=(0.0001, 0.02)), 10).to(device)
+    model = ddi.DiffusionModel(3, ddi.VarianceSchedule(n_time_steps=1000, beta_start_end=(0.0001, 0.02)), 10, 32).to(
+        device
+    )
     _ = model(pseudo_batch, pseudo_time_steps, pseudo_labels)


### PR DESCRIPTION
Manage configuration via hydra instead of a simple `params.py` file. The different models and datasets can now be switched via the config, and the DVC pipeline has been adapted to only train a single model at a time.